### PR TITLE
Fix logic on how PHPUnit for WP is fetched

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 # This uses newer and faster docker based build system
-sudo: false
 
 language: php
 
@@ -7,11 +6,12 @@ notifications:
   on_success: never
   on_failure: change
 
+services:
+  - mysql
+
 php:
   - nightly # PHP 7.0
   - 5.6
-  - 5.5
-  - 5.4
 
 env:
   - WP_PROJECT_TYPE=plugin WP_VERSION=latest WP_MULTISITE=0 WP_TEST_URL=http://localhost:12000 WP_TEST_USER=test WP_TEST_USER_PASS=test

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -50,9 +50,14 @@ install_wp() {
 
   if [ $WP_VERSION == 'latest' ]; then
     local ARCHIVE_NAME='latest'
+    # fetch the latest wordpress version code
+    VERSION_CODE=$(curl -s "https://api.wordpress.org/core/version-check/1.7/" | jq -r '[.offers[]|select(.response=="upgrade")][0].version')
   else
     local ARCHIVE_NAME="wordpress-$WP_VERSION"
+    VERSION_CODE="${WP_VERSION}"
   fi
+
+  VERSION_CODE=${VERSION_CODE:0:3}
 
   download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
   tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
@@ -72,7 +77,10 @@ install_test_suite() {
   if [ ! "$(ls -A $WP_TESTS_DIR)" ]; then
     # set up testing suite
     mkdir -p $WP_TESTS_DIR
-    svn co --quiet http://develop.svn.wordpress.org/trunk/tests/phpunit/includes/ $WP_TESTS_DIR
+    cd $WP_TESTS_DIR
+    git clone --single-branch --branch $VERSION_CODE https://github.com/WordPress/wordpress-develop.git
+    cd wordpress-develop
+    mv tests/phpunit/includes/* $WP_TESTS_DIR
   fi
 
   cd $WP_TESTS_DIR


### PR DESCRIPTION
Always downloading the latest PHPUnit from the Wordpress.org SVN resulted in incombatible tests being run.

For example, in the nightly version that comes after the release 5.4.2, PHPMailer was renamed from `class-phpmailer.php` to `PHPMailer.php`.
Due to this, the tests try to run the file only present in the nightly release.

Now fetch the tests from WordPress.org GitHub mirror and use the correct version number.